### PR TITLE
ci: add linting check for ci using rust clippy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Clippy check
+
+# Make sure CI fails on all warnings, including Clippy lints
+env:
+  RUSTFLAGS: "-Dwarnings"
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features


### PR DESCRIPTION
## Description
This provides an extensive linting to the rust code using [Rust-Clippy](https://doc.rust-lang.org/nightly/clippy/) compared to `cargo check` which cover a [subset](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html) of what clippy can do. Clippy has [more than 550 lints](https://rust-lang.github.io/rust-clippy/master/index.html). It _can_ make the project robust in the long run.

## Related Issue


## Types of changes
- [ ] Bug fix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (corrections, enhancements, or additions to documentation)
- [x] Other (please describe): lints to catch common mistakes and improve the Rust code
